### PR TITLE
Improve Windows Compatibility & Fix Cache File Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 
 ```lua
 {
-  mvn_executable = 'mvn', -- Example: mvn, ./mvnw or a path to Maven executable
+  mvn_executable = 'mvn', -- Example: mvn, ./mvnw or a path to Maven executable, if you are on windows use mvn.cmd
   project_scanner_depth = 5,
   console = {
     show_command_execution = true,

--- a/lua/maven/parsers/help_options_cache_parser.lua
+++ b/lua/maven/parsers/help_options_cache_parser.lua
@@ -25,8 +25,12 @@ M.dump = function(options)
   local options_text = vim.json.encode(options)
   local help_options_json = Path:new(Utils.maven_cache_path, 'help_options.json')
 
-  if not help_options_json:parent():exists() then
-      help_options_json:parent():mkdir({ parents = true })
+  print("Cache Path: " .. Utils.maven_cache_path)
+
+  local parent_path = help_options_json:parent()
+    if not parent_path:exists() then
+      parent_path:mkdir({ parents = true })
+      print("Created directory: " .. tostring(parent_path))
   end
 
   if not help_options_json:exists() then

--- a/lua/maven/parsers/help_options_cache_parser.lua
+++ b/lua/maven/parsers/help_options_cache_parser.lua
@@ -25,7 +25,7 @@ M.dump = function(options)
   local options_text = vim.json.encode(options)
   local help_options_json = Path:new(Utils.maven_cache_path, 'help_options.json')
 
-  if not path:exists() then
+  if not help_options_json:exists() then
       help_options_json:mkdir({ parents = true })
   end
 

--- a/lua/maven/parsers/help_options_cache_parser.lua
+++ b/lua/maven/parsers/help_options_cache_parser.lua
@@ -12,6 +12,7 @@ local M = {}
 M.parse = function()
   --- @type Path
   local help_options_json = Path:new(Utils.maven_cache_path, 'help_options.json')
+  print("Cache Path: " .. Utils.maven_cache_path)
   if help_options_json:exists() then
     local data = help_options_json:read()
     return vim.json.decode(data)

--- a/lua/maven/parsers/help_options_cache_parser.lua
+++ b/lua/maven/parsers/help_options_cache_parser.lua
@@ -25,8 +25,8 @@ M.dump = function(options)
   local options_text = vim.json.encode(options)
   local help_options_json = Path:new(Utils.maven_cache_path, 'help_options.json')
 
-  if not help_options_json:exists() then
-      help_options_json:mkdir({ parents = true })
+  if not help_options_json:parent():exists() then
+      help_options_json:parent():mkdir({ parents = true })
   end
 
   help_options_json:write(options_text, 'w')

--- a/lua/maven/parsers/help_options_cache_parser.lua
+++ b/lua/maven/parsers/help_options_cache_parser.lua
@@ -24,6 +24,11 @@ end
 M.dump = function(options)
   local options_text = vim.json.encode(options)
   local help_options_json = Path:new(Utils.maven_cache_path, 'help_options.json')
+
+  if not path:exists() then
+      help_options_json:mkdir({ parents = true })
+  end
+
   help_options_json:write(options_text, 'w')
 end
 

--- a/lua/maven/parsers/help_options_cache_parser.lua
+++ b/lua/maven/parsers/help_options_cache_parser.lua
@@ -29,6 +29,11 @@ M.dump = function(options)
       help_options_json:parent():mkdir({ parents = true })
   end
 
+  if not help_options_json:exists() then
+      help_options_json:touch({ recursive = true })
+  end
+
+
   help_options_json:write(options_text, 'w')
 end
 

--- a/lua/maven/parsers/help_options_cache_parser.lua
+++ b/lua/maven/parsers/help_options_cache_parser.lua
@@ -12,7 +12,6 @@ local M = {}
 M.parse = function()
   --- @type Path
   local help_options_json = Path:new(Utils.maven_cache_path, 'help_options.json')
-  print("Cache Path: " .. Utils.maven_cache_path)
   if help_options_json:exists() then
     local data = help_options_json:read()
     return vim.json.decode(data)
@@ -26,12 +25,10 @@ M.dump = function(options)
   local options_text = vim.json.encode(options)
   local help_options_json = Path:new(Utils.maven_cache_path, 'help_options.json')
 
-  print("Cache Path: " .. Utils.maven_cache_path)
 
   local parent_path = help_options_json:parent()
     if not parent_path:exists() then
       parent_path:mkdir({ parents = true })
-      print("Created directory: " .. tostring(parent_path))
   end
 
   if not help_options_json:exists() then

--- a/lua/maven/sources/init.lua
+++ b/lua/maven/sources/init.lua
@@ -20,7 +20,8 @@ local console = require('maven.utils.console')
 
 local uv = vim.loop
 
-local pom_xml_file_pattern = '**/pom.xml$'
+local pom_xml_file_pattern = "[\\/]+pom%.xml$"
+
 
 local M = {}
 

--- a/lua/maven/utils/init.lua
+++ b/lua/maven/utils/init.lua
@@ -35,12 +35,18 @@ M.local_central_catalog_path =
   Path:new(M.maven_local_repository_path, 'archetype-catalog-central.xml')
 
 M.get_plugin_root_dir = function()
-  local source = debug.getinfo(1).source
-  local dir_path = source:match('@(.*/)') or source:match('@(.*\\)')
-  if dir_path == nil then
-    return nil
-  end
-  return dir_path .. '..'
+    local source = debug.getinfo(1).source
+
+    if jit and jit.os and string.lower(jit.os) == 'windows' then
+        source = source:gsub('/', '\\')
+    end
+
+    local dir_path = source:match('@(.*/)') or source:match('@(.*\\)')
+    if dir_path == nil then
+        return nil
+    end
+
+    return dir_path .. '..'
 end
 
 M.humanize_size = function(size)

--- a/lua/maven/utils/init.lua
+++ b/lua/maven/utils/init.lua
@@ -35,18 +35,18 @@ M.local_central_catalog_path =
   Path:new(M.maven_local_repository_path, 'archetype-catalog-central.xml')
 
 M.get_plugin_root_dir = function()
-    local source = debug.getinfo(1).source
+  local source = debug.getinfo(1).source
 
-    if jit and jit.os and string.lower(jit.os) == 'windows' then
-        source = source:gsub('/', '\\')
-    end
+  if jit and jit.os and string.lower(jit.os) == 'windows' then
+    source = source:gsub('/', '\\')
+  end
 
-    local dir_path = source:match('@(.*/)') or source:match('@(.*\\)')
-    if dir_path == nil then
-        return nil
-    end
+  local dir_path = source:match('@(.*/)') or source:match('@(.*\\)')
+  if dir_path == nil then
+    return nil
+  end
 
-    return dir_path .. '..'
+  return dir_path .. '..'
 end
 
 M.humanize_size = function(size)

--- a/lua/maven/utils/init.lua
+++ b/lua/maven/utils/init.lua
@@ -45,7 +45,6 @@ M.get_plugin_root_dir = function()
   if dir_path == nil then
     return nil
   end
-
   return dir_path .. '..'
 end
 


### PR DESCRIPTION
Hey! I made some improvements to make the plugin work better on Windows.

- Fixed Windows compatibility – The plugin now runs correctly without issues.
- Cache file creation fix – Previously, using the default option from the README could cause an error because cache files weren’t being created.
- README update – Added a small note for Windows users to run mvn as mvn.cmd to avoid potential issues.

These changes should make the setup smoother, especially for Windows users. Let me know if anything needs tweaking! 🚀

PS: Nice work you have done!